### PR TITLE
Add support for statements cache

### DIFF
--- a/sqlalchemy_turbodbc/dialect.py
+++ b/sqlalchemy_turbodbc/dialect.py
@@ -59,6 +59,7 @@ class MSExecutionContext_turbodbc(MSExecutionContext):
 class MSDialect_turbodbc(TurbodbcConnector, MSDialect):
 
     default_paramstyle = 'qmark'
+    supports_statement_cache = True
 
     execution_ctx_cls = MSExecutionContext_turbodbc
 


### PR DESCRIPTION
Using sqlalchemy-turbodbc with SQL Alchemy 1.4.x will yield the below warning:

_sqlalchemy.exc.SAWarning: Dialect mssql:turbodbc will not make use of SQL
compilation caching as it does not set the 'supports_statement_cache'
attribute to ``True``. This can have significant performance implications
including some performance degradations in comparison to prior SQLAlchemy
versions. Dialect maintainers should seek to set this attribute to True
after appropriate development and testing for SQLAlchemy 1.4 caching
support. Alternatively, this attribute may be set to False which will
disable this warning._

I've had a look over [this link](https://docs.sqlalchemy.org/en/14/faq/performance.html) and based on that and a review of the code I don't see any reason given that `MSDialect_turbodbc` extends `MSDialect` (and there's not too much heavy lifting going on in it) that it can't also be enabled there.

I did some basic testing of some use cases (ORM queries, some auto-mapping) and saw both that the warning message went away and there weren't any other errors that were created as a result of this change.