### PR TITLE
Remove square brackets from error in is_disconnect

### DIFF
--- a/sqlalchemy_turbodbc/connector.py
+++ b/sqlalchemy_turbodbc/connector.py
@@ -132,14 +132,9 @@ class TurbodbcConnector(Connector):
         return [dsn, connect_args]
 
     def is_disconnect(self, e, connection, cursor):
-        # if isinstance(e, self.dbapi.ProgrammingError):
-        #     return "The cursor's connection has been closed." in str(e) or \
-        #         'Attempt to use a closed connection.' in str(e)
         if isinstance(e, self.dbapi.Error):
-            for code in (
-                    '08S01', '01002', '08003', '08007',
-                    '08S02', '08001', 'HYT00', 'HY010'):
-                if code in str(e):
-                    return True
+            return "The cursor's connection has been closed." in str(
+                e
+            ) or "Attempt to use a closed connection." in str(e)
         else:
             return False

--- a/sqlalchemy_turbodbc/connector.py
+++ b/sqlalchemy_turbodbc/connector.py
@@ -136,6 +136,10 @@ class TurbodbcConnector(Connector):
         #     return "The cursor's connection has been closed." in str(e) or \
         #         'Attempt to use a closed connection.' in str(e)
         if isinstance(e, self.dbapi.Error):
-            return '08S01' in str(e)
+            for code in (
+                    '08S01', '01002', '08003', '08007',
+                    '08S02', '08001', 'HYT00', 'HY010'):
+                if code in str(e):
+                    return True
         else:
             return False

--- a/sqlalchemy_turbodbc/connector.py
+++ b/sqlalchemy_turbodbc/connector.py
@@ -136,6 +136,6 @@ class TurbodbcConnector(Connector):
         #     return "The cursor's connection has been closed." in str(e) or \
         #         'Attempt to use a closed connection.' in str(e)
         if isinstance(e, self.dbapi.Error):
-            return '[08S01]' in str(e)
+            return '08S01' in str(e)
         else:
             return False

--- a/sqlalchemy_turbodbc/dialect.py
+++ b/sqlalchemy_turbodbc/dialect.py
@@ -92,3 +92,25 @@ class MSDialect_turbodbc(TurbodbcConnector, MSDialect):
                 except ValueError:
                     version.append(n)
             return tuple(version)
+
+
+    def is_disconnect(self, e, connection, cursor):
+        if isinstance(e, self.dbapi.Error):
+            msg = e.args[0]
+            disconnect_codes = {
+                "08S01",
+                "01000",
+                "01002",
+                "08003",
+                "08007",
+                "08S02",
+                "08001",
+                "HYT00",
+                "HY010",
+                "10054",
+            }
+            if any(code in msg for code in disconnect_codes):
+                return True
+        return super(MSDialect_turbodbc, self).is_disconnect(
+            e, connection, cursor
+        )


### PR DESCRIPTION
I noticed a while ago I were getting some dodgy behaviour when using `pool_pre_ping=True` on a SQLAlchemy engine (see: https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic) - despite adding the argument we weren't getting correct re-connect behaviour when connections had been invalidated.

I noticed that on the error output of our ODBC driver that the error code was the same as here, minus the square brackets. I'm not sure if the square brackets were there for a reason initially but having removed them, the re-connect logic works on my side.

If there's another way you'd like this done please let me know and I'd be happy to re-work things as applicable!