### PR TITLE
Strings are no longer candidates for execution in sqlalchemy 2.x

### DIFF
--- a/sqlalchemy_turbodbc/dialect.py
+++ b/sqlalchemy_turbodbc/dialect.py
@@ -19,7 +19,7 @@
 import re
 
 from sqlalchemy.dialects.mssql.base import MSExecutionContext, MSDialect
-from sqlalchemy import exc
+from sqlalchemy import exc, text
 
 from .connector import TurbodbcConnector
 
@@ -76,7 +76,7 @@ class MSDialect_turbodbc(TurbodbcConnector, MSDialect):
         try:
             # SERVERPROPERTY returns the SQL_VARIANT type which is not
             # supported, so we cast it to varchar
-            stmt = "SELECT CAST(SERVERPROPERTY('ProductVersion') AS VARCHAR)"
+            stmt = text("SELECT CAST(SERVERPROPERTY('ProductVersion') AS VARCHAR)")
             raw = connection.scalar(stmt)
         except exc.DBAPIError:
             # SQL Server docs indicate this function isn't present prior to


### PR DESCRIPTION
I noticed this morning that when we try and get the server version as part of opening a new connection it fails. This is because since 2.x, raw Python strings are no longer eligible for execution - they need to be wrapped in `text()` or similar. 

I've verified this works in 2.x and also checked that it was backward-compatible with 1.4.x.