### PR TITLE
Add matching for error message returned by turbodbc

### DIFF
--- a/sqlalchemy_turbodbc/connector.py
+++ b/sqlalchemy_turbodbc/connector.py
@@ -133,8 +133,10 @@ class TurbodbcConnector(Connector):
 
     def is_disconnect(self, e, connection, cursor):
         if isinstance(e, self.dbapi.Error):
-            return "The cursor's connection has been closed." in str(
-                e
-            ) or "Attempt to use a closed connection." in str(e)
+            return (
+                "The cursor's connection has been closed." in str(e)
+                or "Attempt to use a closed connection." in str(e)
+                or "Connection already closed" in str(e)
+            )
         else:
             return False


### PR DESCRIPTION
Comes from here https://github.com/blue-yonder/turbodbc/blob/master/python/turbodbc/connection.py#L10.

I think these two pre-existing ones are copied from pyodbc impl? Have kept them there as well in case someone is relying on that behavior