### PR TITLE
Keep precision of decimal binds

### DIFF
--- a/sqlalchemy_turbodbc/connector.py
+++ b/sqlalchemy_turbodbc/connector.py
@@ -24,7 +24,18 @@ class _TurboDecimal(sqltypes.DECIMAL):
     Copyright (c) 2016-2017 Blue Yonder GmbH
     """
     def bind_processor(self, dialect):
-        return super(_TurboDecimal, self).bind_processor(dialect)
+        if self.asdecimal:
+	    # in line with turbodbc approach to send decimal as string
+            def to_str(value):
+                if value is None:
+                    return None
+                else:
+                    # handles scentific notation Decimals
+                    return "{:f}".format(value)
+
+            return to_str
+        else:
+            return super(_TurboDecimal, self).bind_processor(dialect)
 
     def result_processor(self, dialect, coltype):
         if self.asdecimal:


### PR DESCRIPTION
As explained by the author of turbodbc, e.g. here https://github.com/blue-yonder/turbodbc/issues/142 and here https://github.com/blue-yonder/turbodbc/issues/82, decimals are transported as strings rather than python Decimals, for various reasons. Doing so in the connector here, when sending values out, allows to avoid the precision loss that is currently taking place when float is used for transport.